### PR TITLE
fix: raise the PennyLane version to >=0.29.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,8 @@ setup(
     install_requires=[
         "amazon-braket-sdk>=1.35.1",
         "scipy>=1.5.2",
-        "pennylane>=0.25.1,<=0.27.0",
+        "pennylane>=0.29.1",
         "openfermion==1.0.0",
-        # https://github.com/PennyLaneAI/pennylane/issues/3867
-        "autoray==0.6.0",
     ],
     extras_require={
         "test": [

--- a/src/braket/experimental/algorithms/chsh_inequality/chsh_inequality.py
+++ b/src/braket/experimental/algorithms/chsh_inequality/chsh_inequality.py
@@ -39,10 +39,10 @@ def create_chsh_inequality_circuits(
     Args:
         qubit0 (Qubit): First qubit.
         qubit1 (Qubit): Second qubit.
-        a1 (float): First basis rotation angle for first qubit
-        a2 (float): Second basis rotation angle for first qubit
-        b1 (float): First basis rotation angle for second qubit
-        b2 (float): Second basis rotation angle for second qubit
+        a1 (float): First basis rotation angle for first qubit.
+        a2 (float): Second basis rotation angle for first qubit.
+        b1 (float): First basis rotation angle for second qubit.
+        b2 (float): Second basis rotation angle for second qubit.
 
     Returns:
         List[Circuit]: List of quantum circuits.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fix: raise the PennyLane version to >=0.29.1

Sets the minimum version of PennyLane to `0.29.1` and removes autoray being pinned as this version of PennyLane takes care of that. 

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws-samples/amazon-braket-algorithm-library/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws-samples/amazon-braket-algorithm-library/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws-samples/amazon-braket-algorithm-library/blob/main/README.md) and [API docs](https://github.com/aws-samples/amazon-braket-algorithm-library/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
